### PR TITLE
wine hack

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -27,6 +27,7 @@ jobs:
         name: x86
         path: |
           Build/netfx4-Debug/x86/*.dll
+          Build/netfx4-Debug/x86/*.pdb
           Build/netfx4-Debug/x86/*.XML
           
     - name: Upload x64 Artifacts
@@ -35,6 +36,7 @@ jobs:
         name: x64
         path: |
           Build/netfx4-Debug/x64/*.dll
+          Build/netfx4-Debug/x64/*.pdb
 
     - name: Upload x64 Artifacts
       uses: actions/upload-artifact@v3


### PR DESCRIPTION
The original wine patch and a slight tweak on RhEnsureThunkIsLoaded so that it would not get stuck in an infinite loop

```
wine hack: it does not look like the address of function VirtualFree can be fetched on wine
wine hack: it does not look like the address of function VirtualProtect can be fetched on wine
```